### PR TITLE
`azurerm_monitor_activity_log_alert` add test for criteria.caller/criteria.level/criteria.recommendation_type/criteria.status/criteria.sub_status/tags

### DIFF
--- a/internal/services/monitor/monitor_activity_log_alert_resource_test.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource_test.go
@@ -146,7 +146,7 @@ func TestAccMonitorActivityLogAlert_basicAndCompleteUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("scopes.#").HasValue("2"),
 				check.That(data.ResourceName).Key("criteria.#").HasValue("1"),
 				check.That(data.ResourceName).Key("criteria.0.operation_name").HasValue("Microsoft.Storage/storageAccounts/write"),
-				check.That(data.ResourceName).Key("criteria.0.category").HasValue("Recommendation"),
+				check.That(data.ResourceName).Key("criteria.0.category").HasValue("Policy"),
 				check.That(data.ResourceName).Key("criteria.0.resource_provider").HasValue("Microsoft.Storage"),
 				check.That(data.ResourceName).Key("criteria.0.resource_type").HasValue("Microsoft.Storage/storageAccounts"),
 				check.That(data.ResourceName).Key("criteria.0.resource_group").Exists(),


### PR DESCRIPTION
### create a internal pull request for `azurerm_monitor_activity_log_alert` add test for criteria.caller/criteria.level/criteria.recommendation_type/criteria.status/criteria.sub_status/tags
**test result :** 
![azurerm_monitor_activity_log_alert complete](https://user-images.githubusercontent.com/46072066/154231039-dd5a1b9f-bca5-4f83-ab32-42978d109467.png)
![azurerm_monitor_activity_log_alert critera](https://user-images.githubusercontent.com/46072066/154231074-871b486e-f1cd-4656-afb3-9b8358b09078.png)

