### PR TITLE
`azurerm_monitor_metric_alert` add test for  dynamic_criteria.evaluation_failure_count/evaluation_total_count/ignore_data_before

### DIFF
--- a/internal/services/monitor/monitor_metric_alert_resource_test.go
+++ b/internal/services/monitor/monitor_metric_alert_resource_test.go
@@ -376,9 +376,12 @@ resource "azurerm_monitor_metric_alert" "test" {
     metric_name      = "CPU Credits Consumed"
     aggregation      = "Average"
 
-    operator               = "GreaterOrLessThan"
-    alert_sensitivity      = "Medium"
-    skip_metric_validation = true
+    operator                 = "GreaterOrLessThan"
+    alert_sensitivity        = "Medium"
+    skip_metric_validation   = true
+    evaluation_failure_count = 4
+    evaluation_total_count   = 5
+    ignore_data_before       = "2022-03-02T15:04:05Z"
   }
   window_size              = "PT5M"
   frequency                = "PT5M"


### PR DESCRIPTION
### create a internal pull request for `azurerm_monitor_metric_alert` add dynamic_criteria.evaluation_failure_count/evaluation_total_count/ignore_data_before
**test result:**
![azurerm_monitor_metric_alert](https://user-images.githubusercontent.com/46072066/159841225-8d1db33f-1226-4263-9c66-16ed1d8cbe61.png)

