### PR TITLE
internal `kubernetes_cluster_node_pool` and `kubernetes_cluster_resource` remove node_labels forceNew

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -653,10 +653,7 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 	}
 
 	if d.HasChange("node_labels") {
-		nodeLabelsRaw := d.Get("node_labels").(map[string]interface{})
-		if nodeLabels := utils.ExpandMapStringPtrString(nodeLabelsRaw); len(nodeLabels) > 0 {
-			props.NodeLabels = nodeLabels
-		}
+		props.NodeLabels = utils.ExpandMapStringPtrString(d.Get("node_labels").(map[string]interface{}))
 	}
 
 	// validate the auto-scale fields are both set/unset to prevent a continual diff

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -163,7 +163,6 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				"node_labels": {
 					Type:     pluginsdk.TypeMap,
 					Optional: true,
-					ForceNew: true,
 					Computed: true,
 					Elem: &pluginsdk.Schema{
 						Type: pluginsdk.TypeString,
@@ -651,6 +650,13 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 	}
 	if d.HasChange("workload_runtime") {
 		props.WorkloadRuntime = containerservice.WorkloadRuntime(d.Get("workload_runtime").(string))
+	}
+
+	if d.HasChange("node_labels") {
+		nodeLabelsRaw := d.Get("node_labels").(map[string]interface{})
+		if nodeLabels := utils.ExpandMapStringPtrString(nodeLabelsRaw); len(nodeLabels) > 0 {
+			props.NodeLabels = nodeLabels
+		}
 	}
 
 	// validate the auto-scale fields are both set/unset to prevent a continual diff

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -371,31 +371,29 @@ func TestAccKubernetesClusterNodePool_modeUpdate(t *testing.T) {
 func TestAccKubernetesClusterNodePool_nodeLabels(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
-	labels1 := map[string]string{"key": "value"}
-	labels2 := map[string]string{"key2": "value2"}
-	labels3 := map[string]string{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.nodeLabelsConfig(data, labels1),
+			Config: r.nodeLabelsConfig(data, map[string]string{"key": "value"}),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("node_labels.%").HasValue("1"),
-				check.That(data.ResourceName).Key("node_labels.key").HasValue("value"),
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 		{
-			Config: r.nodeLabelsConfig(data, labels2),
+			Config: r.nodeLabelsConfig(data, map[string]string{"key2": "value2"}),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("node_labels.%").HasValue("1"),
-				check.That(data.ResourceName).Key("node_labels.key2").HasValue("value2"),
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 		{
-			Config: r.nodeLabelsConfig(data, labels3),
+			Config: r.nodeLabelsConfig(data, map[string]string{}),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("node_labels.%").HasValue("0"),
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -1397,7 +1395,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "manual" {
 func (r KubernetesClusterNodePoolResource) nodeLabelsConfig(data acceptance.TestData, labels map[string]string) string {
 	labelsSlice := make([]string, 0, len(labels))
 	for k, v := range labels {
-		labelsSlice = append(labelsSlice, fmt.Sprintf("    \"%s\" = \"%s\"", k, v))
+		labelsSlice = append(labelsSlice, fmt.Sprintf(`    "%s" = "%s"`, k, v))
 	}
 	labelsStr := strings.Join(labelsSlice, "\n")
 	return fmt.Sprintf(`

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -145,32 +145,29 @@ func TestAccKubernetesCluster_linuxProfile(t *testing.T) {
 func TestAccKubernetesCluster_nodeLabels(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
-	labels1 := map[string]string{"key": "value"}
-	labels2 := map[string]string{"key2": "value2"}
-	labels3 := map[string]string{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.nodeLabelsConfig(data, labels1),
+			Config: r.nodeLabelsConfig(data, map[string]string{"key": "value"}),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_labels.key").HasValue("value"),
 			),
 		},
+		data.ImportStep(),
 		{
-			Config: r.nodeLabelsConfig(data, labels2),
+			Config: r.nodeLabelsConfig(data, map[string]string{"key2": "value2"}),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("default_node_pool.0.node_labels.key2").HasValue("value2"),
 			),
 		},
+		data.ImportStep(),
 		{
-			Config: r.nodeLabelsConfig(data, labels3),
+			Config: r.nodeLabelsConfig(data, map[string]string{}),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				acceptance.TestCheckNoResourceAttr(data.ResourceName, "default_node_pool.0.node_labels"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -1104,7 +1101,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 func (KubernetesClusterResource) nodeLabelsConfig(data acceptance.TestData, labels map[string]string) string {
 	labelsSlice := make([]string, 0, len(labels))
 	for k, v := range labels {
-		labelsSlice = append(labelsSlice, fmt.Sprintf("      \"%s\" = \"%s\"", k, v))
+		labelsSlice = append(labelsSlice, fmt.Sprintf(`    "%s" = "%s"`, k, v))
 	}
 	labelsStr := strings.Join(labelsSlice, "\n")
 	return fmt.Sprintf(`

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -31,6 +32,37 @@ func TestAccKubernetesCluster_hostEncryption(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("default_node_pool.0.enable_host_encryption").HasValue("true"),
+			),
+		},
+	})
+}
+
+func TestAccKubernetesCluster_defaultNodePool(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+	labels1 := map[string]string{"key": "value"}
+	labels2 := map[string]string{"key2": "value2"}
+	labels3 := map[string]string{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.defaultNodePool(data, labels1),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("default_node_pool.0.node_labels.%").HasValue("1"),
+				check.That(data.ResourceName).Key("default_node_pool.0.node_labels.key").HasValue("value"),
+			),
+		},
+		{
+			Config: r.defaultNodePool(data, labels2),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("default_node_pool.0.node_labels.%").HasValue("1"),
+				check.That(data.ResourceName).Key("default_node_pool.0.node_labels.key2").HasValue("value2"),
+			),
+		},
+		{
+			Config: r.defaultNodePool(data, labels3),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("default_node_pool.0.node_labels.%").HasValue("0"),
 			),
 		},
 	})
@@ -114,6 +146,46 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, controlPlaneVersion)
+}
+
+func (KubernetesClusterResource) defaultNodePool(data acceptance.TestData, labels map[string]string) string {
+	labelsSlice := make([]string, 0, len(labels))
+	for k, v := range labels {
+		labelsSlice = append(labelsSlice, fmt.Sprintf("    \"%s\" = \"%s\"", k, v))
+	}
+	labelsStr := strings.Join(labelsSlice, "\n")
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+  kubernetes_version  = "1.22.4"
+
+  default_node_pool {
+    name                   = "default"
+    node_count             = 1
+    vm_size                = "Standard_DS2_v2"
+    enable_host_encryption = true
+    node_labels = {
+		%[3]s
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, labelsStr)
 }
 
 func (r KubernetesClusterResource) upgradeSettingsConfig(data acceptance.TestData, maxSurge string) string {

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -177,7 +177,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     vm_size                = "Standard_DS2_v2"
     enable_host_encryption = true
     node_labels = {
-		%[3]s
+%[3]s
     }
   }
 

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -125,7 +125,6 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 
 					"node_labels": {
 						Type:     pluginsdk.TypeMap,
-						ForceNew: true,
 						Optional: true,
 						Computed: true,
 						Elem: &pluginsdk.Schema{

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -333,7 +333,7 @@ A `default_node_pool` block supports the following:
 
 * `node_public_ip_prefix_id` - (Optional) Resource ID for the Public IP Addresses Prefix for the nodes in this Node Pool. `enable_node_public_ip` should be `true`. Changing this forces a new resource to be created.
 
-* `node_labels` - (Optional) A map of Kubernetes labels which should be applied to nodes in the Default Node Pool. Changing this forces a new resource to be created.
+* `node_labels` - (Optional) A map of Kubernetes labels which should be applied to nodes in the Default Node Pool.
 
 * `only_critical_addons_enabled` - (Optional) Enabling this option will taint default node pool with `CriticalAddonsOnly=true:NoSchedule` taint. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -97,7 +97,7 @@ The following arguments are supported:
 
 * `mode` - (Optional) Should this Node Pool be used for System or User resources? Possible values are `System` and `User`. Defaults to `User`.
 
-* `node_labels` - (Optional) A map of Kubernetes labels which should be applied to nodes in this Node Pool. Changing this forces a new resource to be created.
+* `node_labels` - (Optional) A map of Kubernetes labels which should be applied to nodes in this Node Pool.
 
 * `node_public_ip_prefix_id` - (Optional) Resource ID for the Public IP Addresses Prefix for the nodes in this Node Pool. `enable_node_public_ip` should be `true`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
### internal `kubernetes_cluster_node_pool` and `kubernetes_cluster_resource` remove node_labels forceNew

**test result after update:**
1: TestAccKubernetesCluster_defaultNodePool
![image](https://user-images.githubusercontent.com/46072066/164960619-48155ecb-718b-4684-af59-a13c5b36b206.png)

2: TestAccKubernetesClusterNodePool_nodeLabels
![image](https://user-images.githubusercontent.com/46072066/164958914-82d722dc-eeea-438f-a268-9503d2ad2e11.png)

