### PR TITLE
`private_link_service_resource` - `fqdns`

### DIFF
--- a/internal/services/network/private_link_service_resource.go
+++ b/internal/services/network/private_link_service_resource.go
@@ -76,6 +76,15 @@ func resourcePrivateLinkService() *pluginsdk.Resource {
 				Set: pluginsdk.HashString,
 			},
 
+			"fqdns": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+
 			// Required by the API you can't create the resource without at least
 			// one ip configuration once primary is set it is set forever unless
 			// you destroy the resource and recreate it.
@@ -190,6 +199,7 @@ func resourcePrivateLinkServiceCreateUpdate(d *pluginsdk.ResourceData, meta inte
 			},
 			IPConfigurations:                     expandPrivateLinkServiceIPConfiguration(primaryIpConfiguration),
 			LoadBalancerFrontendIPConfigurations: expandPrivateLinkServiceFrontendIPConfiguration(loadBalancerFrontendIpConfigurations),
+			Fqdns:                                utils.ExpandStringSlice(d.Get("fqdns").([]interface{})),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -269,6 +279,10 @@ func resourcePrivateLinkServiceRead(d *pluginsdk.ResourceData, meta interface{})
 		}
 		if err := d.Set("visibility_subscription_ids", subscriptions); err != nil {
 			return fmt.Errorf("setting `visibility_subscription_ids`: %+v", err)
+		}
+
+		if err := d.Set("fqdns", utils.FlattenStringSlice(props.Fqdns)); err != nil {
+			return fmt.Errorf("setting `fqdns`: %+v", err)
 		}
 
 		if err := d.Set("nat_ip_configuration", flattenPrivateLinkServiceIPConfiguration(props.IPConfigurations)); err != nil {

--- a/internal/services/network/private_link_service_resource_test.go
+++ b/internal/services/network/private_link_service_resource_test.go
@@ -716,7 +716,7 @@ resource "azurerm_private_link_service" "test" {
   resource_group_name            = azurerm_resource_group.test.name
   auto_approval_subscription_ids = [data.azurerm_subscription.current.subscription_id]
   visibility_subscription_ids    = [data.azurerm_subscription.current.subscription_id]
-  fqdns                          = ["a.a.a.a.a"]
+  fqdns                          = ["foo.com", "bar.com"]
 
   nat_ip_configuration {
     name                       = "primaryIpConfiguration-%d"

--- a/internal/services/network/private_link_service_resource_test.go
+++ b/internal/services/network/private_link_service_resource_test.go
@@ -716,6 +716,7 @@ resource "azurerm_private_link_service" "test" {
   resource_group_name            = azurerm_resource_group.test.name
   auto_approval_subscription_ids = [data.azurerm_subscription.current.subscription_id]
   visibility_subscription_ids    = [data.azurerm_subscription.current.subscription_id]
+  fqdns                          = ["a.a.a.a.a"]
 
   nat_ip_configuration {
     name                       = "primaryIpConfiguration-%d"

--- a/website/docs/r/private_link_service.html.markdown
+++ b/website/docs/r/private_link_service.html.markdown
@@ -102,6 +102,8 @@ The following arguments are supported:
 
 * `enable_proxy_protocol` - (Optional) Should the Private Link Service support the Proxy Protocol? Defaults to `false`.
 
+* `fqdns` - (Optional) The list of Fqdn.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
 
 * `visibility_subscription_ids` - (Optional) A list of Subscription UUID/GUID's that will be able to see this Private Link Service.

--- a/website/docs/r/private_link_service.html.markdown
+++ b/website/docs/r/private_link_service.html.markdown
@@ -102,7 +102,7 @@ The following arguments are supported:
 
 * `enable_proxy_protocol` - (Optional) Should the Private Link Service support the Proxy Protocol? Defaults to `false`.
 
-* `fqdns` - (Optional) The list of Fqdn.
+* `fqdns` - (Optional) List of FQDNs allowed for the Private Link Service.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
### internal pr for `private_link_service_resource` - `fqdns`
**result after update:**
TestAccPrivateLinkService_complete:
![image](https://user-images.githubusercontent.com/46072066/175459862-675c6df1-b42f-4beb-839c-b3e5ba95ac1c.png)
